### PR TITLE
Added server_url config setting

### DIFF
--- a/config/swagger-ui.php
+++ b/config/swagger-ui.php
@@ -46,6 +46,11 @@ return [
             'modify_file' => true,
 
             /*
+             * The server URL configuration for the swagger file. Defaults to the app URL.
+             */
+            'server_url' => config('app.url'),
+
+            /*
              * The oauth configuration for the swagger file.
              */
             'oauth' => [

--- a/config/swagger-ui.php
+++ b/config/swagger-ui.php
@@ -46,9 +46,9 @@ return [
             'modify_file' => true,
 
             /*
-             * The server URL configuration for the swagger file. Defaults to the app URL.
+             * The server URL configuration for the swagger file.
              */
-            'server_url' => config('app.url'),
+            'server_url' => env('APP_URL'),
 
             /*
              * The oauth configuration for the swagger file.

--- a/src/Http/Controllers/OpenApiJsonController.php
+++ b/src/Http/Controllers/OpenApiJsonController.php
@@ -57,7 +57,7 @@ class OpenApiJsonController
         }
 
         $json['servers'] = [
-            ['url' => config('swagger-ui.server_url', config('app.url'))],
+            ['url' => $file['server_url'] ?? config('app.url')],
         ];
 
         return $json;

--- a/src/Http/Controllers/OpenApiJsonController.php
+++ b/src/Http/Controllers/OpenApiJsonController.php
@@ -57,7 +57,7 @@ class OpenApiJsonController
         }
 
         $json['servers'] = [
-            ['url' => config('app.url')],
+            ['url' => config('swagger-ui.server_url', config('app.url'))],
         ];
 
         return $json;

--- a/tests/OpenApiRouteTest.php
+++ b/tests/OpenApiRouteTest.php
@@ -52,6 +52,24 @@ class OpenApiRouteTest extends TestCase
      *
      * @dataProvider openApiFileProvider
      */
+    public function it_uses_a_custom_server_url_if_defined_in_config($openApiFile)
+    {
+        config()->set('app.url', 'http://foo.bar');
+        config()->set('swagger-ui.files.0.versions', ['v1' => $openApiFile]);
+        config()->set('swagger-ui.files.0.modify_file', true);
+        config()->set('swagger-ui.server_url', 'http://foo.bar/api');
+
+        $this->get('swagger/v1')
+            ->assertStatus(200)
+            ->assertJsonCount(1, 'servers')
+            ->assertJsonPath('servers.0.url', 'http://foo.bar/api');
+    }
+
+    /**
+     * @test
+     *
+     * @dataProvider openApiFileProvider
+     */
     public function it_sets_oauth_urls_by_combining_configured_paths_with_current_app_url_if_modify_file_is_enabled($openApiFile)
     {
         config()->set('swagger-ui.files.0.versions', ['v1' => $openApiFile]);

--- a/tests/OpenApiRouteTest.php
+++ b/tests/OpenApiRouteTest.php
@@ -39,6 +39,7 @@ class OpenApiRouteTest extends TestCase
     {
         config()->set('swagger-ui.files.0.versions', ['v1' => $openApiFile]);
         config()->set('swagger-ui.files.0.modify_file', true);
+        config()->set('swagger-ui.files.0.server_url', null);
         config()->set('app.url', 'http://foo.bar');
 
         $this->get('swagger/v1')
@@ -57,7 +58,7 @@ class OpenApiRouteTest extends TestCase
         config()->set('app.url', 'http://foo.bar');
         config()->set('swagger-ui.files.0.versions', ['v1' => $openApiFile]);
         config()->set('swagger-ui.files.0.modify_file', true);
-        config()->set('swagger-ui.server_url', 'http://foo.bar/api');
+        config()->set('swagger-ui.files.0.server_url', 'http://foo.bar/api');
 
         $this->get('swagger/v1')
             ->assertStatus(200)


### PR DESCRIPTION
If you don't like this method or want anything changed just let me know! 

Updated `configureServer()` to check for the `config('swagger-ui.server_url')` setting first before falling back on `config('app.url')`. Added test to verify this works as expected.

Closes #37